### PR TITLE
Add Firebase authentication scaffolding

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,16 @@
     "git:status": "git status"
   },
   "dependencies": {
-    "hono": "^4.9.2"
+    "firebase": "^11.0.0",
+    "hono": "^4.9.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "@hono/vite-build": "^1.2.0",
     "@hono/vite-dev-server": "^0.18.2",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
     "typescript": "^5.9.2",
     "vite": "^6.3.5",
     "wrangler": "^4.4.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,36 @@
+/** @jsxImportSource react */
+import { collection, addDoc } from "firebase/firestore";
+import { AuthProvider, useAuth } from "./AuthContext";
+import Login from "./Login";
+import { db } from "./firebase";
+
+function Dashboard() {
+  const { user } = useAuth();
+
+  const addTestDoc = async () => {
+    await addDoc(collection(db, "transactions"), {
+      user: user?.uid,
+      amount: 50,
+      createdAt: new Date()
+    });
+  };
+
+  if (!user) return <Login />;
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <p>You are logged in as {user.email}</p>
+      <button onClick={addTestDoc}>Add Firestore Test Doc</button>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <Dashboard />
+    </AuthProvider>
+  );
+}
+

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,0 +1,23 @@
+/** @jsxImportSource react */
+import { createContext, useContext, useEffect, useState } from "react";
+import { onAuthStateChanged, User } from "firebase/auth";
+import { auth } from "./firebase";
+
+const AuthContext = createContext<{ user: User | null }>({ user: null });
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    return onAuthStateChanged(auth, setUser);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);
+

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,0 +1,30 @@
+/** @jsxImportSource react */
+import { signInWithPopup, signOut } from "firebase/auth";
+import { auth, provider } from "./firebase";
+import { useAuth } from "./AuthContext";
+
+export default function Login() {
+  const { user } = useAuth();
+
+  const handleLogin = async () => {
+    await signInWithPopup(auth, provider);
+  };
+
+  const handleLogout = async () => {
+    await signOut(auth);
+  };
+
+  return (
+    <div>
+      {user ? (
+        <>
+          <p>Welcome, {user.displayName || user.email}</p>
+          <button onClick={handleLogout}>Logout</button>
+        </>
+      ) : (
+        <button onClick={handleLogin}>Login with Google</button>
+      )}
+    </div>
+  );
+}
+

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,18 @@
+import { initializeApp } from "firebase/app";
+import { getAuth, GoogleAuthProvider } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
+
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_PROJECT.appspot.com",
+  messagingSenderId: "YOUR_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const provider = new GoogleAuthProvider();
+export const db = getFirestore(app);
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "strict": true,
     "skipLibCheck": true,
     "lib": [
-      "ESNext"
+      "ESNext",
+      "DOM"
     ],
     "types": ["vite/client"],
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- add Firebase, React, and React DOM dependencies
- introduce Firebase config, Auth context, and login components
- wire basic dashboard example with Firestore

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npx tsc --noEmit` *(fails: Cannot find module 'firebase/firestore' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68aacdfe0040832d9eea31d6284c4bf0